### PR TITLE
Open workshop items with Steam

### DIFF
--- a/scripts/tools/uploader.js
+++ b/scripts/tools/uploader.js
@@ -96,7 +96,7 @@ async function _runUploader(toolsDir, uploaderParams) {
 
 // Returns steam workshop url for mod
 function formUrl(modId) {
-    return 'http://steamcommunity.com/sharedfiles/filedetails/?id=' + modId;
+    return 'steam://url/CommunityFilePage/' + modId;
 }
 
 exports.uploadMod = uploadMod;


### PR DESCRIPTION
Use the [Steam browser protocol] to open workshop items.
This bypasses the need for users to log in (in the browser) to be able to subscribe to ther own mods.

**Example:** VMF workshop page (GitHub forbids non-HTTP links).

```
steam://url/CommunityFilePage/1369573612
```

[Steam browser protocol]: https://developer.valvesoftware.com/wiki/Steam_browser_protocol